### PR TITLE
CI on three operating systems and two JDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  bb:
+    name: babashka (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2022]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install babashka dev build
+        run: |
+          bash <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install) --dev-build --dir . --dynamic
+
+      # Runs the suite through babashka's built-in babashka.ffi, so the calls
+      # go through the compiled trampolines instead of FFM handles.
+      - name: Run tests
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then bb=./bb.exe; else bb=./bb; fi
+          "$bb" test:bb
+
+  jvm:
+    name: JVM ${{ matrix.jdk }} (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-2022]
+        jdk: ['22', '25']
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+
+      - uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          cli: latest
+
+      - name: Run tests
+        run: clojure -M:test


### PR DESCRIPTION
One job runs the suite through a babashka dev build, where the calls take the compiled trampolines. The other runs it on the JVM against JDK 22, the minimum this library supports, and JDK 25.