### PR TITLE
Skip the C call where there is no default lookup

### DIFF
--- a/test/babashka/ffi_test.clj
+++ b/test/babashka/ffi_test.clj
@@ -9,13 +9,22 @@
             [clojure.test :refer [deftest is testing]]))
 
 ;; strlen lives in the C runtime, which the default lookup finds on every OS
+;; that has one. Binding is lazy, so this is safe even where it does not.
 (defcfn strlen "strlen" [:string] :long)
+
+(def default-lookup?
+  "A statically linked musl binary has no dlopen and no FFM default lookup,
+  so it cannot reach the C runtime by name. Memory still works there, so only
+  the tests that call a C function ask this."
+  (delay (try (strlen "probe") true (catch Throwable _ false))))
 
 (def point [:struct [[:x :int] [:y :int]]])
 
 (deftest call-test
-  (testing "a C call through the default lookup"
-    (is (= 5 (strlen "hello")))))
+  (if-not @default-lookup?
+    (println "C call skipped: this build has no default lookup")
+    (testing "a C call through the default lookup"
+      (is (= 5 (strlen "hello"))))))
 
 (deftest memory-test
   (testing "an arena allocation roundtrip"


### PR DESCRIPTION
A statically linked musl binary has no dlopen and no way to reach the C runtime by name, so binding strlen there cannot resolve. Babashka's own suite has always skipped for this; the library's did not, and nothing ran it in such a build until it joined babashka's lib tests.

The test asks whether the lookup works rather than reading babashka's build flag, since this library also runs on the JVM and should not branch on a consumer's build. Only the C call is skipped: memory, layouts and structs need no lookup and still run.