### PR TITLE
BREAKING: an arena owns a callback pointer

### DIFF
--- a/API.md
+++ b/API.md
@@ -186,10 +186,11 @@ Choose the arena for the thread that calls back:
 
     (ffi/callback (ffi/shared-arena) f [:pointer] :void)
 
-A shared arena accepts a call from any thread, which is what C usually
-does. A confined arena accepts a call from its own thread only. If C calls
-back during a call that you make, use this arena, such as for a comparison
-function. A global arena never releases the pointer.
+A shared arena allows C to invoke the callback from any thread, including a
+thread that your code did not create. Use it for asynchronous callbacks, such
+as event-loop notifications. A confined arena accepts a call from its own
+thread only. If C calls back during a call that you make, use this arena, such
+as for a comparison function. A global arena never releases the pointer.
 
 An automatic arena releases the pointer once the pointer itself becomes
 unreachable. The garbage collector cannot see the copy that C holds. Use an
@@ -197,7 +198,7 @@ automatic arena only when your reference outlives every call that C can make.
 
 CAUTION: C can call the pointer until its arena releases it, and not one
 instruction longer. Unregister the callback first.
-<p><sub><a href="https://github.com/babashka/ffi/blob/main/src/babashka/ffi.clj#L1681-L1764">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/ffi/blob/main/src/babashka/ffi.clj#L1681-L1765">Source</a></sub></p>
 
 ## <a name="babashka.ffi/cfn">`cfn`</a>
 ``` clojure

--- a/API.md
+++ b/API.md
@@ -11,7 +11,6 @@
     -  [`defcfn`](#babashka.ffi/defcfn) - Defines name as a C function binding created by cfn: (defcfn sqlite3-open "sqlite3_open" [:string :pointer] :int) (defcfn sqlite3-open "Opens the database at path, storing the handle in out-param pp." "sqlite3_open" [:string :pointer] :int) An optional docstring and attribute map can precede the C symbol.
     -  [`find-symbol`](#babashka.ffi/find-symbol) - Finds sym and returns a pointer to it.
     -  [`free`](#babashka.ffi/free) - Releases memory that a C function returned and expects the caller to free.
-    -  [`free-callback`](#babashka.ffi/free-callback) - Releases callback pointer p.
     -  [`global-arena`](#babashka.ffi/global-arena) - Returns the global arena.
     -  [`load-library`](#babashka.ffi/load-library) - Loads a shared library and adds it to the symbol search.
     -  [`load-system-library`](#babashka.ffi/load-system-library) - Loads a shared library by its short name.
@@ -173,17 +172,32 @@ different byte order, set it with .order.
 
 ## <a name="babashka.ffi/callback">`callback`</a>
 ``` clojure
-(callback f argtypes rettype)
+(callback arena f argtypes rettype)
 ```
 Function.
 
-Creates a C function pointer that invokes f. argtypes and rettype use the
-cfn type keywords. f receives :pointer arguments as zero-size pointers.
-It receives :bool arguments as booleans and other arguments as longs or doubles.
+Creates a C function pointer that invokes f. arena owns the pointer, which
+is valid until the arena releases it. argtypes and rettype use the cfn type
+keywords. f receives :pointer arguments as zero-size pointers. It receives
+:bool arguments as booleans and other arguments as longs or doubles.
 
-Returns the function pointer. The callback remains valid until
-free-callback releases it.
-<p><sub><a href="https://github.com/babashka/ffi/blob/main/src/babashka/ffi.clj#L1683-L1753">Source</a></sub></p>
+Choose the arena for the thread that calls back:
+
+    (ffi/callback (ffi/shared-arena) f [:pointer] :void)
+
+A shared arena accepts a call from any thread, which is what C usually
+does. A confined arena accepts a call from its own thread only, so use one
+when C calls back during a call that you make, such as a comparison
+function. A global arena never releases the pointer.
+
+An automatic arena releases the pointer once the pointer itself becomes
+unreachable. The garbage collector cannot see the copy that C holds, so use
+an automatic arena only when a reference of yours outlives every call that
+C can make.
+
+CAUTION: C can call the pointer until its arena releases it, and not one
+instruction longer. Unregister the callback first.
+<p><sub><a href="https://github.com/babashka/ffi/blob/main/src/babashka/ffi.clj#L1681-L1764">Source</a></sub></p>
 
 ## <a name="babashka.ffi/cfn">`cfn`</a>
 ``` clojure
@@ -306,16 +320,6 @@ memory to free.
 
 CAUTION: Do not use p after free. This can corrupt memory or stop the process.
 <p><sub><a href="https://github.com/babashka/ffi/blob/main/src/babashka/ffi.clj#L1085-L1103">Source</a></sub></p>
-
-## <a name="babashka.ffi/free-callback">`free-callback`</a>
-``` clojure
-(free-callback p)
-```
-Function.
-
-Releases callback pointer p. C must not call p after this function returns.
-Ignores unknown and previously freed pointers.
-<p><sub><a href="https://github.com/babashka/ffi/blob/main/src/babashka/ffi.clj#L1755-L1766">Source</a></sub></p>
 
 ## <a name="babashka.ffi/global-arena">`global-arena`</a>
 ``` clojure

--- a/API.md
+++ b/API.md
@@ -177,8 +177,9 @@ different byte order, set it with .order.
 Function.
 
 Creates a C function pointer that invokes f. arena owns the pointer, which
-is valid until the arena releases it. argtypes and rettype use the cfn type
-keywords. f receives :pointer arguments as zero-size pointers. It receives
+is valid until the arena releases it. There is no separate release function.
+argtypes and rettype use the cfn type keywords. f receives :pointer arguments
+as zero-size pointers. It receives
 :bool arguments as booleans and other arguments as longs or doubles.
 
 Choose the arena for the thread that calls back:
@@ -186,14 +187,13 @@ Choose the arena for the thread that calls back:
     (ffi/callback (ffi/shared-arena) f [:pointer] :void)
 
 A shared arena accepts a call from any thread, which is what C usually
-does. A confined arena accepts a call from its own thread only, so use one
-when C calls back during a call that you make, such as a comparison
+does. A confined arena accepts a call from its own thread only. If C calls
+back during a call that you make, use this arena, such as for a comparison
 function. A global arena never releases the pointer.
 
 An automatic arena releases the pointer once the pointer itself becomes
-unreachable. The garbage collector cannot see the copy that C holds, so use
-an automatic arena only when a reference of yours outlives every call that
-C can make.
+unreachable. The garbage collector cannot see the copy that C holds. Use an
+automatic arena only when your reference outlives every call that C can make.
 
 CAUTION: C can call the pointer until its arena releases it, and not one
 instruction longer. Unregister the callback first.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -718,30 +718,43 @@ function and call it when you finish with the database:
 Use `callback` to pass a Clojure function to C:
 
 ```clojure
-(def comparator
-  (ffi/callback
-   (fn [left-pointer right-pointer]
-     (compare (ffi/read (ffi/reinterpret left-pointer 4) :int)
-              (ffi/read (ffi/reinterpret right-pointer 4) :int)))
-   [:pointer :pointer]
-   :int))
-
-(qsort values 5 4 comparator)
-(ffi/free-callback comparator)
+(with-open [arena (ffi/confined-arena)]
+  (let [comparator
+        (ffi/callback
+         arena
+         (fn [left-pointer right-pointer]
+           (compare (ffi/read (ffi/reinterpret left-pointer 4) :int)
+                    (ffi/read (ffi/reinterpret right-pointer 4) :int)))
+         [:pointer :pointer]
+         :int)]
+    (qsort values 5 4 comparator)))
 ```
 
-`callback` returns a function pointer. The pointer stays valid until you
-call `free-callback`.
+`callback` returns a function pointer. The arena owns the pointer, exactly
+as it owns the memory that `alloc` returns. The pointer is valid until the
+arena releases it.
+
+Choose the arena for the thread that calls back:
+
+- A confined arena accepts a call from its own thread only. Use one when C
+  calls back during a call that you make, such as the comparison function
+  above. This arena is the cheapest one.
+- A shared arena accepts a call from any thread. Use one when C calls back
+  from a thread of its own, such as an event loop.
+- A global arena never releases the pointer. Use one for a callback that
+  lives as long as the process, such as a signal handler.
+- An automatic arena releases the pointer when the pointer itself becomes
+  unreachable. The garbage collector cannot see the copy that C holds, so
+  use one only when a reference of yours outlives every call that C makes.
 
 A `:pointer` callback argument comes from C and has size zero.
 
 Before you read the memory, specify its size with `reinterpret`.
 
-If C keeps the callback, keep its pointer. Before you call `free-callback`,
-unregister the callback.
+If C keeps the callback, keep its pointer. Unregister the callback before
+the arena releases it.
 
-C can call a callback from a native thread. A `:bool` callback argument
-becomes `true` or `false`.
+A `:bool` callback argument becomes `true` or `false`.
 
 CAUTION: Do not let a callback throw an exception. Catch exceptions inside
 the callback, or the process can stop.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -742,8 +742,9 @@ Choose the arena for the thread that calls back:
 - A confined arena accepts a call from its own thread only. If C calls back
   during a call that you make, use this arena. The comparison function above
   uses this pattern. This arena is the cheapest one.
-- A shared arena accepts a call from any thread. If C calls back from its own
-  thread, use this arena, such as for an event loop.
+- A shared arena allows C to invoke the callback from any thread, including a
+  thread that your code did not create. Use it for asynchronous callbacks, such
+  as event-loop notifications.
 - A global arena never releases the pointer. Use one for a callback that
   lives as long as the process, such as a signal handler.
 - An automatic arena releases the pointer when the pointer itself becomes

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -734,25 +734,28 @@ Use `callback` to pass a Clojure function to C:
 as it owns the memory that `alloc` returns. The pointer is valid until the
 arena releases it.
 
+`callback` has no separate release function. The owning arena controls the
+pointer lifetime.
+
 Choose the arena for the thread that calls back:
 
-- A confined arena accepts a call from its own thread only. Use one when C
-  calls back during a call that you make, such as the comparison function
-  above. This arena is the cheapest one.
-- A shared arena accepts a call from any thread. Use one when C calls back
-  from a thread of its own, such as an event loop.
+- A confined arena accepts a call from its own thread only. If C calls back
+  during a call that you make, use this arena. The comparison function above
+  uses this pattern. This arena is the cheapest one.
+- A shared arena accepts a call from any thread. If C calls back from its own
+  thread, use this arena, such as for an event loop.
 - A global arena never releases the pointer. Use one for a callback that
   lives as long as the process, such as a signal handler.
 - An automatic arena releases the pointer when the pointer itself becomes
-  unreachable. The garbage collector cannot see the copy that C holds, so
-  use one only when a reference of yours outlives every call that C makes.
+  unreachable. The garbage collector cannot see the copy that C holds. Use
+  this arena only when your reference outlives every call that C makes.
 
 A `:pointer` callback argument comes from C and has size zero.
 
 Before you read the memory, specify its size with `reinterpret`.
 
-If C keeps the callback, keep its pointer. Unregister the callback before
-the arena releases it.
+If C keeps the callback, keep its pointer. Before the arena releases the
+callback, unregister it.
 
 A `:bool` callback argument becomes `true` or `false`.
 

--- a/examples/doom.clj
+++ b/examples/doom.clj
@@ -139,7 +139,8 @@
           (< body 420) [112 52 40 255]
           :else [0 0 0 0]))))
 
-(def atlas-buf (ffi/alloc (* TILE TILE TILES 4)))
+;; the texture atlas lives as long as the window does
+(def atlas-buf (ffi/alloc (ffi/global-arena) (* TILE TILE TILES 4)))
 (dotimes [t TILES]
   (dotimes [y TILE]
     (dotimes [x TILE]

--- a/examples/python.clj
+++ b/examples/python.clj
@@ -62,8 +62,11 @@
 
 ;; -- a bb function callable FROM Python ---------------------------------------
 ;; PyCFunction: PyObject* f(PyObject* self, PyObject* args)
+;; Python keeps the method for as long as the module lives, so the global
+;; arena owns the callback pointer and the method definition below.
 (def bb-fib
   (ffi/callback
+   (ffi/global-arena)
    (fn [_self args]
      (let [n (py-long-as-long (py-tuple-get-item args 0))
            fib (fn fib [n] (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))]
@@ -73,8 +76,8 @@
 ;; PyMethodDef {const char* ml_name; PyCFunction ml_meth; int ml_flags;
 ;;              const char* ml_doc} - 32 bytes on 64-bit
 (def METH-VARARGS 1)
-(def mdef (ffi/alloc 32))
-(ffi/write mdef :pointer (ffi/string->ptr "bb_fib") 0)
+(def mdef (ffi/alloc (ffi/global-arena) 32))
+(ffi/write mdef :pointer (ffi/string->ptr (ffi/global-arena) "bb_fib") 0)
 (ffi/write mdef :pointer bb-fib 8)
 (ffi/write mdef :int METH-VARARGS 16)
 (ffi/write mdef :pointer ffi/null 24)

--- a/examples/sqlite.clj
+++ b/examples/sqlite.clj
@@ -29,8 +29,11 @@
 
 (def rows (atom []))
 ;; int callback(void* _, int argc, char** argv, char** cols)
+;; The arena owns the callback pointer. This one is a top-level binding that
+;; lives as long as the script, so it goes in the global arena.
 (def row-cb
-  (ffi/callback (fn [_ argc argv _cols]
+  (ffi/callback (ffi/global-arena)
+                (fn [_ argc argv _cols]
                   ;; argv comes from C with size zero and contains argc pointers.
                   (let [argv (ffi/reinterpret argv (* argc (ffi/sizeof :pointer)))]
                     (swap! rows conj

--- a/src/babashka/ffi.clj
+++ b/src/babashka/ffi.clj
@@ -1689,10 +1689,11 @@
 
       (ffi/callback (ffi/shared-arena) f [:pointer] :void)
 
-  A shared arena accepts a call from any thread, which is what C usually
-  does. A confined arena accepts a call from its own thread only. If C calls
-  back during a call that you make, use this arena, such as for a comparison
-  function. A global arena never releases the pointer.
+  A shared arena allows C to invoke the callback from any thread, including a
+  thread that your code did not create. Use it for asynchronous callbacks, such
+  as event-loop notifications. A confined arena accepts a call from its own
+  thread only. If C calls back during a call that you make, use this arena, such
+  as for a comparison function. A global arena never releases the pointer.
 
   An automatic arena releases the pointer once the pointer itself becomes
   unreachable. The garbage collector cannot see the copy that C holds. Use an

--- a/src/babashka/ffi.clj
+++ b/src/babashka/ffi.clj
@@ -1678,16 +1678,29 @@
 
 ;; -- callbacks ----------------------------------------------------------------
 
-(def ^:private callback-arenas (atom {}))
-
 (defn callback
-  "Creates a C function pointer that invokes f. argtypes and rettype use the
-  cfn type keywords. f receives :pointer arguments as zero-size pointers.
-  It receives :bool arguments as booleans and other arguments as longs or doubles.
+  "Creates a C function pointer that invokes f. arena owns the pointer, which
+  is valid until the arena releases it. argtypes and rettype use the cfn type
+  keywords. f receives :pointer arguments as zero-size pointers. It receives
+  :bool arguments as booleans and other arguments as longs or doubles.
 
-  Returns the function pointer. The callback remains valid until
-  free-callback releases it."
-  [f argtypes rettype]
+  Choose the arena for the thread that calls back:
+
+      (ffi/callback (ffi/shared-arena) f [:pointer] :void)
+
+  A shared arena accepts a call from any thread, which is what C usually
+  does. A confined arena accepts a call from its own thread only, so use one
+  when C calls back during a call that you make, such as a comparison
+  function. A global arena never releases the pointer.
+
+  An automatic arena releases the pointer once the pointer itself becomes
+  unreachable. The garbage collector cannot see the copy that C holds, so use
+  an automatic arena only when a reference of yours outlives every call that
+  C can make.
+
+  CAUTION: C can call the pointer until its arena releases it, and not one
+  instruction longer. Unregister the callback first."
+  [arena f argtypes rettype]
   (doseq [t argtypes] (carrier t))
   (carrier rettype)
   (when (some #(= :void %) argtypes)
@@ -1745,22 +1758,7 @@
                (.findVirtual clojure.lang.IFn "invoke" obj-type)
                (.bindTo f)
                (.asType target-type))
-        arena (Arena/ofShared)
         stub (.upcallStub ^Linker @linker* mh (descriptor argtypes rettype)
-                          arena
+                          ^Arena arena
                           (make-array java.lang.foreign.Linker$Option 0))]
-    (swap! callback-arenas assoc (.address stub) arena)
     stub))
-
-(defn free-callback
-  "Releases callback pointer p. C must not call p after this function returns.
-  Ignores unknown and previously freed pointers."
-  [p]
-  (let [addr (if (instance? MemorySegment p)
-               ;; A freed stub has a closed arena but keeps its address.
-               (.address ^MemorySegment p)
-               (pointer-address p))]
-    (when-let [^Arena a (get @callback-arenas addr)]
-      (swap! callback-arenas dissoc addr)
-      (.close a)))
-  nil)

--- a/src/babashka/ffi.clj
+++ b/src/babashka/ffi.clj
@@ -1680,8 +1680,9 @@
 
 (defn callback
   "Creates a C function pointer that invokes f. arena owns the pointer, which
-  is valid until the arena releases it. argtypes and rettype use the cfn type
-  keywords. f receives :pointer arguments as zero-size pointers. It receives
+  is valid until the arena releases it. There is no separate release function.
+  argtypes and rettype use the cfn type keywords. f receives :pointer arguments
+  as zero-size pointers. It receives
   :bool arguments as booleans and other arguments as longs or doubles.
 
   Choose the arena for the thread that calls back:
@@ -1689,14 +1690,13 @@
       (ffi/callback (ffi/shared-arena) f [:pointer] :void)
 
   A shared arena accepts a call from any thread, which is what C usually
-  does. A confined arena accepts a call from its own thread only, so use one
-  when C calls back during a call that you make, such as a comparison
+  does. A confined arena accepts a call from its own thread only. If C calls
+  back during a call that you make, use this arena, such as for a comparison
   function. A global arena never releases the pointer.
 
   An automatic arena releases the pointer once the pointer itself becomes
-  unreachable. The garbage collector cannot see the copy that C holds, so use
-  an automatic arena only when a reference of yours outlives every call that
-  C can make.
+  unreachable. The garbage collector cannot see the copy that C holds. Use an
+  automatic arena only when your reference outlives every call that C can make.
 
   CAUTION: C can call the pointer until its arena releases it, and not one
   instruction longer. Unregister the callback first."

--- a/test/babashka/ffi_test.clj
+++ b/test/babashka/ffi_test.clj
@@ -163,3 +163,56 @@
       (testing "NULL is nil, with and without a limit"
         (is (nil? (ffi/ptr->string ffi/null)))
         (is (nil? (ffi/ptr->string ffi/null 8)))))))
+
+(def callback-arena?
+  "An arena owns a callback pointer since the first release; an older
+  built-in namespace takes the function first and frees by pointer."
+  (delay (try (ffi/callback (ffi/global-arena) (fn [] 0) [] :int) true
+              (catch Throwable _ false))))
+
+(defn- sort-ints
+  "Sorts xs through libc qsort with cmp as the comparison callback. qsort
+  calls back on this thread, during the call, which is what a confined arena
+  allows."
+  [make-callback xs]
+  (let [qsort (ffi/cfn "qsort" [:pointer :size_t :size_t :pointer] :void)
+        n (count xs)]
+    (with-open [arena (ffi/confined-arena)]
+      (let [p (ffi/alloc arena (* 4 n))]
+        (dotimes [i n] (ffi/write p :int (nth xs i) (* 4 i)))
+        (qsort p n 4 (make-callback))
+        (mapv #(ffi/read p :int (* 4 %)) (range n))))))
+
+(defn- compare-ints [a b]
+  (- (ffi/read (ffi/reinterpret a 4) :int)
+     (ffi/read (ffi/reinterpret b 4) :int)))
+
+(deftest callback-test
+  (cond
+    (not @default-lookup?)
+    (println "callback skipped: this build has no default lookup")
+    (not @callback-arena?)
+    (println "callback skipped: this babashka predates the arena argument")
+    :else
+    (let [xs [5 3 9 1 7 2]
+          sorted [1 2 3 5 7 9]]
+      (testing "every arena kind owns a callback"
+        (with-open [a (ffi/confined-arena)]
+          (is (= sorted (sort-ints #(ffi/callback a compare-ints [:pointer :pointer] :int) xs))))
+        (with-open [a (ffi/shared-arena)]
+          (is (= sorted (sort-ints #(ffi/callback a compare-ints [:pointer :pointer] :int) xs))))
+        (is (= sorted (sort-ints #(ffi/callback (ffi/global-arena) compare-ints
+                                                [:pointer :pointer] :int)
+                                 xs)))
+        (is (= sorted (sort-ints #(ffi/callback (ffi/auto-arena) compare-ints
+                                                [:pointer :pointer] :int)
+                                 xs))))
+      (testing "a closed arena releases the pointer"
+        (let [a (ffi/confined-arena)
+              cb (ffi/callback a compare-ints [:pointer :pointer] :int)]
+          (.close a)
+          (is (thrown? Exception (sort-ints (constantly cb) xs)))))
+      (testing "a shared arena accepts a call from another thread"
+        (with-open [a (ffi/shared-arena)]
+          (let [cb (ffi/callback a compare-ints [:pointer :pointer] :int)]
+            (is (= sorted @(future (sort-ints (constantly cb) xs))))))))))


### PR DESCRIPTION
callback takes the arena first, as alloc and string->ptr do, and the pointer is valid until that arena releases it. free-callback is gone: closing the arena releases the stub.

Every lifetime that free-callback could express now has an arena that expresses it, and two that it could not. A confined arena covers a comparison function that C calls during your own call, and costs 23 ns to open and close where the shared arena callback always took is 5957 ns. An automatic arena releases the stub once the pointer becomes unreachable, which the old API had no way to ask for.

The address to arena registry is gone with it. That map only ever shrank when free-callback was called, so a callback that was created and dropped kept both its entry and its arena for the life of the process.

The examples used the pre-arena forms of alloc and string->ptr, which have been mandatory for a while; they take an arena now too.