### PR TITLE
[perf] jvm: specialize return conversion at binding creation

### DIFF
--- a/src/babashka/ffi/impl/proxy.clj
+++ b/src/babashka/ffi/impl/proxy.clj
@@ -11,7 +11,7 @@
   babashka.ffi loads this namespace while it loads itself, on the JVM only.
   A native image calls through its trampolines and never includes this
   code. Do not require this namespace directly."
-  (:import [java.lang.foreign Linker]
+  (:import [java.lang.foreign Linker MemorySegment]
            [java.lang.invoke MethodHandle MethodHandleProxies MethodHandles MethodType]))
 
 (set! *warn-on-reflection* true)
@@ -73,10 +73,21 @@
     (arg-coercer t)
     (fn ^long [a] (Double/doubleToRawLongBits (double a)))))
 
-(defn- bits-ret-fn [carrier narrow-ret rettype]
-  (case (carrier rettype)
-    :long (fn [^long r] (narrow-ret rettype r))
-    (fn [^long r] (narrow-ret rettype (Double/longBitsToDouble r)))))
+(defn- bits-ret-fn [narrow-ret rettype]
+  ;; Resolve the type once, keeping the raw result primitive until conversion.
+  (case rettype
+    :void (fn [^long _] nil)
+    :bool (fn [^long r] (not (zero? r)))
+    (:int :int32) (fn [^long r] (long (unchecked-int r)))
+    (:uint :uint32) (fn [^long r] (bit-and r 0xFFFFFFFF))
+    :int16 (fn [^long r] (long (unchecked-short r)))
+    :uint16 (fn [^long r] (bit-and r 0xFFFF))
+    (:int8 :byte :char) (fn [^long r] (long (unchecked-byte r)))
+    :uint8 (fn [^long r] (bit-and r 0xFF))
+    (:double :float) (fn [^long r] (Double/longBitsToDouble r))
+    :pointer (fn [^long r] (MemorySegment/ofAddress r))
+    :string (fn [^long r] (narrow-ret :string r))
+    (fn [^long r] r)))
 
 (defmacro ^:private proxy-caller
   "A fn of n arguments that coerces each with the fn at its index in cs,
@@ -132,7 +143,7 @@
         fixed ((proxy-callers [n void?])
                pd
                (object-array (map #(bits-coercer carrier arg-coercer %) argtypes))
-               (bits-ret-fn carrier narrow-ret rettype))]
+               (bits-ret-fn narrow-ret rettype))]
     (if (some #(= :string %) argtypes)
       ;; strings need a temporary arena that has to outlive the call
       (fn [& args]

--- a/test/babashka/ffi_test.clj
+++ b/test/babashka/ffi_test.clj
@@ -744,6 +744,43 @@
                                 (ffi/callback arena (fn [_ _ _ _ _] 0)
                                               [:long :long :long :long :double] :long))))))))
 
+(deftest jvm-return-conversion-test
+  (when-not (System/getProperty "babashka.version")
+    (with-open [arena (ffi/confined-arena)]
+      (doseq [[t cases]
+              [[:int [[0 0] [2147483647 2147483647] [2147483648 -2147483648] [4294967295 -1]]]
+               [:int32 [[4294967295 -1]]]
+               [:uint [[-1 4294967295] [4294967296 0]]]
+               [:uint32 [[-1 4294967295]]]
+               [:int16 [[32768 -32768] [65535 -1]]]
+               [:uint16 [[-1 65535] [65536 0]]]
+               [:int8 [[128 -128] [255 -1]]]
+               [:byte [[255 -1]]]
+               [:char [[255 -1]]]
+               [:uint8 [[-1 255] [256 0]]]
+               [:long [[Long/MIN_VALUE Long/MIN_VALUE] [Long/MAX_VALUE Long/MAX_VALUE]]]
+               [:ulong [[-1 -1]]]
+               [:int64 [[Long/MIN_VALUE Long/MIN_VALUE]]]
+               [:uint64 [[-1 -1]]]
+               [:size_t [[4294967296 4294967296]]]
+               [:ssize_t [[-1 -1]]]]]
+        (let [cb (ffi/callback arena identity [:long] t)
+              call (ffi/cfn cb [:long] t)]
+          (doseq [[input expected] cases]
+            (is (= expected (call input)) (str t " " input)))))
+      (doseq [t [:double :float]]
+        (let [cb (ffi/callback arena identity [t] t)
+              call (ffi/cfn cb [t] t)]
+          (doseq [value [0.0 -0.0 1.25 Double/POSITIVE_INFINITY Double/NEGATIVE_INFINITY]]
+            (is (= (Double/doubleToRawLongBits value)
+                   (Double/doubleToRawLongBits (double (call value)))) (str t " " value)))
+          (is (Double/isNaN (double (call Double/NaN)))))))
+    (with-open [arena (ffi/confined-arena)]
+      (let [cb (ffi/callback arena identity [:bool] :bool)
+            call (ffi/cfn cb [:bool] :bool)]
+        (is (true? (call true)))
+        (is (false? (call false)))))))
+
 (deftest binding-diagnostics-test
   ;; JVM only: in babashka the built-in namespace can be older than this
   ;; checkout


### PR DESCRIPTION
This pr chooses the return converter once when creating a JVM binding. This removes per-call type dispatch and intermediate boxing.

I found this bottleneck this while working on the https://github.com/andersmurphy/sqlite4clj port, profiling a 2x slowdown compared to coffi.